### PR TITLE
Prevent Segfaults and Add Data Corruption Checks

### DIFF
--- a/hangover.cpp
+++ b/hangover.cpp
@@ -68,7 +68,7 @@ void markAllocated(void * ptr, size_t sz) {
   allocs.push_back(ptr);
 
   // Fill with a known value.
-  // This has to be done in the same exact way that `simulateMalloc` will check
+  // This has to be done in the same exact way that `simulateFree` will check
   // for later. Otherwise, it will spuriously abort.
   for (auto ind = 0; ind < sz; ind++) {
     ((char *) ptr)[ind] = ('M' + ind + (uintptr_t) ptr) % 256;


### PR DESCRIPTION
This Pull Request modifies two parts of the original `hangover.cpp` code.

First, the `simulateRealloc` method was not checking for failures. It simply dereferenced the `newPtr`, causing spurious segmentation faults. This PR adds a check to ensure that the value returned by `HANGOVER_REALLOC` is non-`NULL` before continuing, failing with a `SIGABRT` otherwise.

Second, this PR reintroduces the checks in `simulateFree` to ensure that the data in the block did not change while it was allocated. This necesitated `markAllocated` and `simulateRealloc` to populate the data in the way `simulateFree` would later check. The `auto` type in `simulateFree` and `simulateRealloc` also had to be explicitly written as `char`, otherwise the check would fail for numbers between 128 (-128) and 255 (-1).