### PR TITLE
Fix/sign extension

### DIFF
--- a/hangover.cpp
+++ b/hangover.cpp
@@ -68,7 +68,7 @@ void markAllocated(void * ptr, size_t sz) {
   allocs.push_back(ptr);
 
   // Fill with a known value.
-  // This has to be done in the same exact way that `simulateMalloc` will check
+  // This has to be done in the same exact way that `simulateFree` will check
   // for later. Otherwise, it will spuriously abort.
   for (auto ind = 0; ind < sz; ind++) {
     ((char *) ptr)[ind] = ('M' + ind + (uintptr_t) ptr) % 256;

--- a/hangover.cpp
+++ b/hangover.cpp
@@ -180,6 +180,8 @@ void simulateRealloc()
   assert(ptr != nullptr);
   assert(newSize != 0);
   auto newPtr = HANGOVER_REALLOC(ptr, newSize);
+  // We do not expect memory exhaustion during fuzzing, though it is of course legal!
+  assert(newPtr);
   // Check AND reset the known value.
   auto minSize = ((sz < newSize) ? sz : newSize);
   auto v = ('M' + (uintptr_t) ptr) % 256;  

--- a/hangover.cpp
+++ b/hangover.cpp
@@ -192,8 +192,8 @@ void simulateRealloc()
   assert(newPtr);
   // Check AND reset the known value.
   auto minSize = ((sz < newSize) ? sz : newSize);
-  auto v = ('M' + (uintptr_t) ptr) % 256;  
-  auto new_v = ('M' + (uintptr_t) newPtr) % 256;
+  char v = ('M' + (uintptr_t) ptr) % 256; //changed auto to char (see comment in simulateMalloc)
+  char new_v = ('M' + (uintptr_t) newPtr) % 256; //changed auto to char (see comment in simulateMalloc)
   for (auto ind = 0; ind < minSize; ind++) {
     //printf("accessing ind %d\n", ind);
     assert(((char *) newPtr)[ind] == v);


### PR DESCRIPTION
Changed the types for `v` (line 195) and `new_v` (line 196) in simulateRealloc from `auto` to `char` due to sign extension errors.